### PR TITLE
Add SimulatorBuilder for configurable simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,18 @@ The example prints the best distance found every few generations.
 
 Add `gantan` to your `Cargo.toml` and implement the required traits (`GenoType`, `PhenoType`, `Inspector` and `Roulette`) for your problem domain.
 
+### Building a simulator
+
+`SimulatorBuilder` provides a convenient chained API to configure a simulator:
+
+```rust
+let mut simulator = SimulatorBuilder::new()
+    .with_population(population)
+    .with_inspector(inspector)
+    .with_crossover_rate(0.9)
+    .with_mutation_rate(0.05)
+    .with_selector(selector)
+    .with_seed(42) // optional
+    .build();
+```
+

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -1,4 +1,4 @@
-use gantan::{GenoType, Inspector, PhenoType, Population, Roulette, Simulator};
+use gantan::{GenoType, Inspector, PhenoType, Population, Roulette, SimulatorBuilder};
 use ordered_float::OrderedFloat;
 use rand::prelude::*;
 
@@ -246,6 +246,13 @@ fn main() {
     let inspector = Ins;
     let selector = CityRoulette::default();
 
-    let mut simulator = Simulator::new(Population::from(p), inspector, 0.9, 0.05, selector);
+    let mut builder = SimulatorBuilder::new();
+    builder
+        .with_population(Population::from(p))
+        .with_inspector(inspector)
+        .with_crossover_rate(0.9)
+        .with_mutation_rate(0.05)
+        .with_selector(selector);
+    let mut simulator = builder.build();
     simulator.start();
 }


### PR DESCRIPTION
## Summary
- introduce `SimulatorBuilder` with fluent setup and optional RNG seed
- switch `Simulator` to use `StdRng`
- update TSP example to use the new builder
- document builder usage in README

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687d1260322c8332bcfdcaeaa3b74d4f