### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,61 @@
 
 `gantan` is a lightweight framework for building Genetic Algorithm (GA) based solutions in Rust. It provides abstractions for genotypes, phenotypes, selection strategies and a simulator to evolve populations.
 
+This crate focuses on providing just the building blocks required to implement a genetic algorithm. You define your own gene representation, how it mutates and how individuals are evaluated. `gantan` then takes care of evolving a population using crossover, mutation and selection.
+
+
 ## Running the example
 
-A sample Traveling Salesman Problem solver is included. You can run it with:
+A sample Traveling Salesman Problem solver is included.
+
+1. Clone the repository
+2. Run the built-in example:
 
 ```shell
 cargo run --release --example tsp
 ```
+
 
 The example prints the best distance found every few generations.
 
 ## Using as a library
 
 Add `gantan` to your `Cargo.toml` and implement the required traits (`GenoType`, `PhenoType`, `Inspector` and `Roulette`) for your problem domain.
+### Defining your types
+
+Implement the following traits for your domain:
+
+```rust
+#[derive(Clone)]
+struct MyGene { /* fields */ }
+
+struct MyPhenotype;
+
+impl GenoType for MyGene {
+    type Fitness = u32;
+    type PhenoType = MyPhenotype;
+
+    fn fitness(&self) -> Self::Fitness { /* ... */ }
+    fn decode(&self) -> Self::PhenoType { /* ... */ }
+    fn mutate(&mut self) { /* ... */ }
+    fn crossover(g1: &mut Self, g2: &mut Self) { /* ... */ }
+}
+
+impl PhenoType for MyPhenotype {
+    type GenoType = MyGene;
+
+    fn encode(&self) -> MyGene { /* ... */ }
+}
+
+struct MyInspector;
+
+impl Inspector<MyGene> for MyInspector {
+    fn inspect(&mut self, generation: usize, _pop: &Population<MyGene>) -> bool {
+        true
+    }
+}
+```
+
 
 ### Building a simulator
 
@@ -29,5 +71,11 @@ let mut simulator = SimulatorBuilder::new()
     .with_selector(selector)
     .with_seed(42) // optional
     .build();
+```
+
+After configuring the builder you obtain a `Simulator`. The `start` method begins the evolution loop:
+
+```rust
+simulator.start();
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+//! Lightweight framework for genetic algorithms.
+//! The crate provides a generic simulator that evolves a population using
+//! selection, crossover and mutation. You supply your own gene and phenotype
+//! types by implementing a small set of traits.
+//! **Traits**
+//! - `GenoType`: describes a genome and how to mutate, crossover and evaluate it.
+//! - `PhenoType`: converts a phenotype to its gene representation.
+//! - `Inspector`: observes each generation and can stop the simulation.
+//! - `Roulette`: selection strategy used when choosing parents.
+
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use rand::SeedableRng;


### PR DESCRIPTION
## Summary
- expand README with overview, how to define traits, and running the example
- add crate-level documentation

## Testing
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_687d42eb70e483329718903dfa88f3d5