### PR TITLE
Add new selection strategies

### DIFF
--- a/examples/selectors.rs
+++ b/examples/selectors.rs
@@ -1,0 +1,49 @@
+use gantan::selection::{FitnessProportionate, RankSelector, TournamentSelector};
+use gantan::{GenoType, Inspector, Population, SimulatorBuilder};
+use std::cell::Cell;
+
+#[derive(Clone)]
+struct Gene(i32);
+
+impl GenoType for Gene {
+    type Fitness = i32;
+    type PhenoType = i32;
+
+    fn fitness(&self) -> Self::Fitness { self.0 }
+    fn decode(&self) -> Self::PhenoType { self.0 }
+    fn mutate(&mut self) {}
+    fn crossover(_: &mut Self, _: &mut Self) {}
+}
+
+#[derive(Default)]
+struct Ins { gen: Cell<usize> }
+
+impl Inspector<Gene> for Ins {
+    fn inspect(&mut self, g: usize, _p: &Population<Gene>) -> bool {
+        if g != self.gen.get() {
+            self.gen.set(g);
+            println!("generation {} best {}", g, _p.get_best().unwrap().0);
+        }
+        g < 10
+    }
+}
+
+fn run_with_selector<S: gantan::Roulette<Gene>>(name: &str, selector: S) {
+    let pop = Population::from(vec![Gene(1), Gene(2), Gene(3)]);
+    let mut builder = SimulatorBuilder::new();
+    builder
+        .with_population(pop)
+        .with_inspector(Ins::default())
+        .with_crossover_rate(0.0)
+        .with_mutation_rate(0.0)
+        .with_selector(selector);
+    let mut sim = builder.build();
+    println!("running with {}", name);
+    sim.start();
+}
+
+fn main() {
+    run_with_selector("fitness", FitnessProportionate::new());
+    run_with_selector("tournament", TournamentSelector::new(2));
+    run_with_selector("rank", RankSelector::new());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,7 @@ where
         let selection_result = rec!("selection", self.select_pairs());
         let crossover_result = rec!("crossover", self.crossover(selection_result));
         let mutation_result = rec!("mutation", self.mutate(crossover_result));
-        let p = rec!("population", Population::from(mutation_result));
-
-        p
+        rec!("population", Population::from(mutation_result))
     }
 
     fn select_pairs(&mut self) -> Vec<(G, G)> {
@@ -99,11 +97,7 @@ where
             }
         }
 
-        parents
-            .into_iter()
-            .map(|(g1, g2)| [g1, g2])
-            .flatten()
-            .collect()
+        parents.into_iter().flat_map(|(g1, g2)| [g1, g2]).collect()
     }
 
     fn mutate(&mut self, mut children: Vec<G>) -> Vec<G> {
@@ -197,6 +191,17 @@ where
     }
 }
 
+impl<G, I, R> Default for SimulatorBuilder<G, I, R>
+where
+    G: GenoType,
+    I: Inspector<G>,
+    R: Roulette<G>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Default)]
 struct Stat {
     inner: HashMap<String, Vec<u128>>,
@@ -204,7 +209,7 @@ struct Stat {
 
 impl Stat {
     fn record(&mut self, tag: &str, value: u128) {
-        let v = self.inner.entry(tag.to_string()).or_insert_with(Vec::new);
+        let v = self.inner.entry(tag.to_string()).or_default();
         v.push(value);
     }
 
@@ -212,7 +217,7 @@ impl Stat {
         println!("[dump]");
         for (k, v) in &self.inner {
             let len = v.len() as u128;
-            let sum = v.into_iter().sum::<u128>();
+            let sum = v.iter().sum::<u128>();
             if len > 0 {
                 println!(
                     "{}\t: average {:6} us,\ttotal {:6} ms",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+
+pub mod selection;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -282,3 +284,5 @@ pub trait Roulette<G: GenoType> {
     fn reset(&mut self, population: &[(G, G::Fitness)]);
     fn choose(&self) -> G;
 }
+
+pub use selection::{FitnessProportionate, RankSelector, TournamentSelector};

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -1,0 +1,211 @@
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::cell::RefCell;
+use crate::{GenoType, Roulette};
+
+/// Fitness proportionate selection (roulette wheel)
+pub struct FitnessProportionate<G: GenoType>
+where
+    G::Fitness: Into<f64> + Copy,
+{
+    inner: Vec<(G, f64)>,
+    sum: f64,
+    rng: RefCell<StdRng>,
+}
+
+impl<G> FitnessProportionate<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: Vec::new(),
+            sum: 0.0,
+            rng: RefCell::new(StdRng::from_entropy()),
+        }
+    }
+
+    pub fn with_seed(seed: u64) -> Self {
+        Self {
+            inner: Vec::new(),
+            sum: 0.0,
+            rng: RefCell::new(StdRng::seed_from_u64(seed)),
+        }
+    }
+}
+
+impl<G> Default for FitnessProportionate<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<G> Roulette<G> for FitnessProportionate<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    fn reset(&mut self, population: &[(G, G::Fitness)]) {
+        self.inner.clear();
+        let mut acc = 0.0;
+        for (g, f) in population {
+            acc += (*f).into();
+            self.inner.push((g.clone(), acc));
+        }
+        self.sum = acc;
+    }
+
+    fn choose(&self) -> G {
+        let mut rng = self.rng.borrow_mut();
+        let r: f64 = rng.gen::<f64>() * self.sum;
+        let mut low = 0usize;
+        let mut high = self.inner.len();
+        while low < high {
+            let mid = (low + high) / 2;
+            if self.inner[mid].1 <= r {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        self.inner[low.min(self.inner.len() - 1)].0.clone()
+    }
+}
+
+/// Tournament selection
+pub struct TournamentSelector<G: GenoType> {
+    size: usize,
+    population: Vec<G>,
+    rng: RefCell<StdRng>,
+    _marker: std::marker::PhantomData<G>,
+}
+
+impl<G: GenoType> TournamentSelector<G> {
+    pub fn new(size: usize) -> Self {
+        Self {
+            size,
+            population: Vec::new(),
+            rng: RefCell::new(StdRng::from_entropy()),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn with_seed(size: usize, seed: u64) -> Self {
+        Self {
+            size,
+            population: Vec::new(),
+            rng: RefCell::new(StdRng::seed_from_u64(seed)),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<G: GenoType> Default for TournamentSelector<G> {
+    fn default() -> Self { Self::new(2) }
+}
+
+impl<G> Roulette<G> for TournamentSelector<G>
+where
+    G: GenoType,
+{
+    fn reset(&mut self, population: &[(G, G::Fitness)]) {
+        self.population = population.iter().map(|(g, _)| g.clone()).collect();
+    }
+
+    fn choose(&self) -> G {
+        let mut rng = self.rng.borrow_mut();
+        let mut best: Option<(G, G::Fitness)> = None;
+        for _ in 0..self.size {
+            let idx = rng.gen_range(0..self.population.len());
+            let g = self.population[idx].clone();
+            let f = g.fitness();
+            match &best {
+                Some((_, bf)) if *bf >= f => {},
+                _ => best = Some((g, f)),
+            }
+        }
+        best.unwrap().0
+    }
+}
+
+/// Rank-based selector
+pub struct RankSelector<G: GenoType>
+where
+    G::Fitness: Into<f64> + Copy,
+{
+    inner: Vec<(G, f64)>,
+    sum: f64,
+    rng: RefCell<StdRng>,
+}
+
+impl<G> RankSelector<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: Vec::new(),
+            sum: 0.0,
+            rng: RefCell::new(StdRng::from_entropy()),
+        }
+    }
+
+    pub fn with_seed(seed: u64) -> Self {
+        Self {
+            inner: Vec::new(),
+            sum: 0.0,
+            rng: RefCell::new(StdRng::seed_from_u64(seed)),
+        }
+    }
+}
+
+impl<G> Default for RankSelector<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    fn default() -> Self { Self::new() }
+}
+
+impl<G> Roulette<G> for RankSelector<G>
+where
+    G: GenoType,
+    G::Fitness: Into<f64> + Copy,
+{
+    fn reset(&mut self, population: &[(G, G::Fitness)]) {
+        self.inner.clear();
+        let mut items: Vec<(G, G::Fitness)> = population.iter().map(|(g, f)| (g.clone(), *f)).collect();
+        items.sort_by_key(|(_, f)| *f);
+        let mut acc = 0.0;
+        for (rank, (g, _)) in items.into_iter().enumerate() {
+            let weight = (rank + 1) as f64; // 1..n
+            acc += weight;
+            self.inner.push((g, acc));
+        }
+        self.sum = acc;
+    }
+
+    fn choose(&self) -> G {
+        let mut rng = self.rng.borrow_mut();
+        let r: f64 = rng.gen::<f64>() * self.sum;
+        let mut low = 0usize;
+        let mut high = self.inner.len();
+        while low < high {
+            let mid = (low + high) / 2;
+            if self.inner[mid].1 <= r {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        self.inner[low.min(self.inner.len() - 1)].0.clone()
+    }
+}
+

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -182,7 +182,7 @@ where
     fn reset(&mut self, population: &[(G, G::Fitness)]) {
         self.inner.clear();
         let mut items: Vec<(G, G::Fitness)> = population.iter().map(|(g, f)| (g.clone(), *f)).collect();
-        items.sort_by_key(|(_, f)| *f);
+        items.sort_by(|(_, f1), (_, f2)| f1.partial_cmp(f2).unwrap_or(std::cmp::Ordering::Equal));
         let mut acc = 0.0;
         for (rank, (g, _)) in items.into_iter().enumerate() {
             let weight = (rank + 1) as f64; // 1..n

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -83,7 +83,6 @@ pub struct TournamentSelector<G: GenoType> {
     size: usize,
     population: Vec<G>,
     rng: RefCell<StdRng>,
-    _marker: std::marker::PhantomData<G>,
 }
 
 impl<G: GenoType> TournamentSelector<G> {

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -1,8 +1,8 @@
+use crate::{GenoType, Roulette};
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::cell::RefCell;
-use crate::{GenoType, Roulette};
 
 /// Fitness proportionate selection (roulette wheel)
 pub struct FitnessProportionate<G: GenoType>
@@ -83,6 +83,7 @@ pub struct TournamentSelector<G: GenoType> {
     size: usize,
     population: Vec<G>,
     rng: RefCell<StdRng>,
+    _marker: std::marker::PhantomData<G>,
 }
 
 impl<G: GenoType> TournamentSelector<G> {
@@ -106,7 +107,9 @@ impl<G: GenoType> TournamentSelector<G> {
 }
 
 impl<G: GenoType> Default for TournamentSelector<G> {
-    fn default() -> Self { Self::new(2) }
+    fn default() -> Self {
+        Self::new(2)
+    }
 }
 
 impl<G> Roulette<G> for TournamentSelector<G>
@@ -125,7 +128,7 @@ where
             let g = self.population[idx].clone();
             let f = g.fitness();
             match &best {
-                Some((_, bf)) if *bf >= f => {},
+                Some((_, bf)) if *bf >= f => {}
                 _ => best = Some((g, f)),
             }
         }
@@ -170,7 +173,9 @@ where
     G: GenoType,
     G::Fitness: Into<f64> + Copy,
 {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<G> Roulette<G> for RankSelector<G>
@@ -180,7 +185,8 @@ where
 {
     fn reset(&mut self, population: &[(G, G::Fitness)]) {
         self.inner.clear();
-        let mut items: Vec<(G, G::Fitness)> = population.iter().map(|(g, f)| (g.clone(), *f)).collect();
+        let mut items: Vec<(G, G::Fitness)> =
+            population.iter().map(|(g, f)| (g.clone(), *f)).collect();
         items.sort_by(|(_, f1), (_, f2)| f1.partial_cmp(f2).unwrap_or(std::cmp::Ordering::Equal));
         let mut acc = 0.0;
         for (rank, (g, _)) in items.into_iter().enumerate() {
@@ -207,4 +213,3 @@ where
         self.inner[low.min(self.inner.len() - 1)].0.clone()
     }
 }
-

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -1,0 +1,76 @@
+use gantan::selection::{FitnessProportionate, TournamentSelector, RankSelector};
+use gantan::{GenoType, Roulette};
+
+#[derive(Clone)]
+struct FG(i32);
+
+impl GenoType for FG {
+    type Fitness = i32;
+    type PhenoType = i32;
+
+    fn fitness(&self) -> Self::Fitness { self.0 }
+    fn decode(&self) -> Self::PhenoType { self.0 }
+    fn mutate(&mut self) {}
+    fn crossover(_g1:&mut Self,_g2:&mut Self){}
+}
+
+#[test]
+fn fitness_proportionate_returns_member() {
+    let genes = vec![FG(1), FG(2), FG(3)];
+    let mut sel = FitnessProportionate::with_seed(42);
+    sel.reset(&[
+        (genes[0].clone(), genes[0].fitness()),
+        (genes[1].clone(), genes[1].fitness()),
+        (genes[2].clone(), genes[2].fitness()),
+    ]);
+    for _ in 0..10 {
+        let g = sel.choose();
+        assert!(genes.iter().any(|x| x.0 == g.0));
+    }
+}
+
+#[test]
+fn tournament_selector_returns_member() {
+    let genes = vec![FG(1), FG(2), FG(3)];
+    let mut sel = TournamentSelector::with_seed(2, 123);
+    sel.reset(&[
+        (genes[0].clone(), genes[0].fitness()),
+        (genes[1].clone(), genes[1].fitness()),
+        (genes[2].clone(), genes[2].fitness()),
+    ]);
+    for _ in 0..10 {
+        let g = sel.choose();
+        assert!(genes.iter().any(|x| x.0 == g.0));
+    }
+}
+
+#[test]
+fn rank_selector_returns_member() {
+    let genes = vec![FG(1), FG(2), FG(3)];
+    let mut sel = RankSelector::with_seed(99);
+    sel.reset(&[
+        (genes[0].clone(), genes[0].fitness()),
+        (genes[1].clone(), genes[1].fitness()),
+        (genes[2].clone(), genes[2].fitness()),
+    ]);
+    for _ in 0..10 {
+        let g = sel.choose();
+        assert!(genes.iter().any(|x| x.0 == g.0));
+    }
+}
+
+#[test]
+fn rank_selector_bias() {
+    let genes = vec![FG(1), FG(10)];
+    let mut sel = RankSelector::with_seed(7);
+    sel.reset(&[
+        (genes[0].clone(), genes[0].fitness()),
+        (genes[1].clone(), genes[1].fitness()),
+    ]);
+    let mut count_best = 0;
+    for _ in 0..100 {
+        let g = sel.choose();
+        if g.0 == 10 { count_best += 1; }
+    }
+    assert!(count_best > 50); // higher ranked should be chosen more often
+}

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -11,7 +11,7 @@ impl GenoType for FG {
     fn fitness(&self) -> Self::Fitness { self.0 }
     fn decode(&self) -> Self::PhenoType { self.0 }
     fn mutate(&mut self) {}
-    fn crossover(_g1:&mut Self,_g2:&mut Self){}
+    fn crossover(_g1: &mut Self, _g2: &mut Self) {}
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement `FitnessProportionate`, `TournamentSelector`, and `RankSelector`
- expose new selectors in crate API
- add tests validating selectors
- demonstrate selector switching in new example

## Testing
- `cargo check`
- `cargo check --examples`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d4350094c83329a13da2b4cbf6920