### PR TITLE
Clamp roulette index

### DIFF
--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -181,6 +181,9 @@ impl<'a> Roulette<Gene<'a>> for CityRoulette<'a> {
                 high = mid;
             }
         }
+        if low == self.inner.len() {
+            low = self.inner.len() - 1;
+        }
         self.inner[low].0.clone()
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -150,3 +150,17 @@ fn weighted_selector_deterministic() {
     assert_eq!(g2, TestGene(2));
     assert_eq!(g3, TestGene(3));
 }
+
+#[test]
+fn weighted_selector_upper_bound() {
+    let g1 = TestGene(1);
+    let g2 = TestGene(2);
+    let draws = vec![1.0];
+    let mut sel = FixedRoulette::new(draws);
+    sel.reset(&[
+        (g1.clone(), g1.fitness()),
+        (g2.clone(), g2.fitness()),
+    ]);
+    let g = sel.choose();
+    assert_eq!(g, TestGene(2));
+}


### PR DESCRIPTION
## Summary
- guard against random draws equal to the total fitness in `CityRoulette::choose`
- test that a roulette selector handles an upper bound draw without panicking

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d487b14208332b41a12a38df1206f